### PR TITLE
Add optional `minConf` argument to `getBalance`

### DIFF
--- a/src/BitcoinJsonRpc.ts
+++ b/src/BitcoinJsonRpc.ts
@@ -331,8 +331,8 @@ export default class BitcoinJsonRpc {
     return this.cmdWithRetryAndDecode(decoders.GetNewAddressResultDecoder, 'getnewaddress');
   }
 
-  public async getBalance() {
-    return this.cmdWithRetryAndDecode(decoders.GetBalanceResultDecoder, 'getbalance');
+  public async getBalance(minConf = 0) {
+    return this.cmdWithRetryAndDecode(decoders.GetBalanceResultDecoder, 'getbalance', '*', minConf); );
   }
 
   public async generateToAddress(nblocks: number, address:string) {


### PR DESCRIPTION
Adds an optional `minConf` argument to the `getBalance` function that defaults to 0.