### PR TITLE
add optional `asset` to `listunspent`

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -344,6 +344,10 @@ export const listUnspentSchema = z.array(
     spendable: z.boolean(),
     solvable: z.union([z.boolean(), z.undefined()]),
     safe: z.union([z.boolean(), z.undefined()]),
+    /**
+     * @description only present for Liquid network
+     */
+    asset: z.union([z.string(), z.undefined()]),
   }),
 );
 


### PR DESCRIPTION
Adds optional `asset` parameter to `listunspent` representing the contract address of liquid tokens